### PR TITLE
Remove ERP code from Legion namecheck

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -34,9 +34,6 @@
 	if(H.real_name == ("Biggus Dickus" || "Bigus Dickus"))
 		H.real_name = "Minimae Coles"
 		H.name = "Minimae Coles"
-		H.lust_tolerance = 0
-		H.sexual_potency = 0
-		H.lust = 0
 
 /datum/outfit/job/CaesarsLegion/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()


### PR DESCRIPTION
## Description
Removes references to ERP datums/vars from the namecheck for legionaries

## Motivation and Context
Another step forward in the removal of the CEO of ERP

## Changelog (necessary)
:cl:
del: Removed ERP vars from legionnaire name check
/:cl:
