### PR TITLE
Experimental Stimpaks are no longer a death sentence

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1765,7 +1765,7 @@ datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/M)
 	reagent_state = LIQUID
 	color = "#e50d0d"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
-	overdose_threshold = 10
+	overdose_threshold = 11
 
 /datum/reagent/medicine/ultra_stimpak/on_mob_life(mob/living/M)
 	if(M.getBruteLoss() == 0 && M.getFireLoss() == 0 && M.getToxLoss() == 0 && M.getOxyLoss() == 0)


### PR DESCRIPTION
## Description
Experimental Stimpaks (admin-spawn only atm) no longer slaughter anyone who uses them.

## Motivation and Context
Exp. Stims give 10 units (like every other stimpak) and instantly OD anyone who takes it, hitting them with a ton (read: 12 TOX per tick) of damage before killing them. Bumping up the OD threshold by a single unit will prevent this from happening, while still having the intended effect of preventing more than one experimental stim to be in the body at any given time.

## Changelog (necessary)
:cl:
fix: Experimental stimpaks no longer kill whoever uses them
/:cl:
